### PR TITLE
Introduce PSR18 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - 7.2
   - 7.3
+  - 7.4
   - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,6 @@
 	"connector"
   ],
   "authors": [
-    {
-      "name": "Simon Dürr",
-      "homepage": "https://www.sc-networks.com"
-    },
 	{
 	  "name": "Johannes Vogt",
 	  "homepage": "https://www.sc-networks.com"
@@ -26,13 +22,14 @@
 	}
   ],
   "require": {
-    "php": ">=7.2",
-    "guzzlehttp/guzzle": "^6.3",
+    "php": ">=7.3",
     "ext-json": "*",
-    "shrikeh/teapot": "^2.3"
+    "psr/http-client": "^1.0",
+    "psr/http-message": "^1.0",
+    "psr/http-factory": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.3"
+    "phpunit/phpunit": "^9"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,30 +1,17 @@
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.3/phpunit.xsd"
-        backupGlobals="true"
-        backupStaticAttributes="false"
-        bootstrap="vendor/autoload.php"
-        cacheTokens="false"
-        colors="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        forceCoversAnnotation="false"
-        verbose="true">
-
-    <testsuites>
-        <testsuite name="Unittests">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">./</directory>
-            <exclude>
-                <directory suffix=".php">vendor/</directory>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="true" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" forceCoversAnnotation="false" verbose="true">
+  <coverage includeUncoveredFiles="false">
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">vendor/</directory>
+      <directory suffix=".php">tests/</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unittests">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Client/CheckpointsClient.php
+++ b/src/Client/CheckpointsClient.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Scn\EvalancheReportingApiConnector\Client;
 
+use Psr\Http\Message\RequestFactoryInterface;
 use Scn\EvalancheReportingApiConnector\EvalancheConfigInterface;
 
 final class CheckpointsClient extends AbstractClient
@@ -11,10 +12,11 @@ final class CheckpointsClient extends AbstractClient
 
     public function __construct(
         ?int $customerId,
-        \GuzzleHttp\Client $http_client,
+        RequestFactoryInterface $requestFactory,
+	    \Psr\Http\Client\ClientInterface $client,
         EvalancheConfigInterface $evalancheConfig
     ) {
-        parent::__construct($http_client, $evalancheConfig);
+        parent::__construct($requestFactory, $client, $evalancheConfig);
         $this->customerId = $customerId;
     }
 

--- a/src/Client/ClientInterface.php
+++ b/src/Client/ClientInterface.php
@@ -3,14 +3,33 @@ declare(strict_types=1);
 
 namespace Scn\EvalancheReportingApiConnector\Client;
 
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+
 interface ClientInterface
 {
+	/**
+	 * @throws ClientExceptionInterface
+	 * @throws NetworkExceptionInterface
+	 */
     public function asJsonArray(): array;
 
+	/**
+	 * @throws ClientExceptionInterface
+	 * @throws NetworkExceptionInterface
+	 */
     public function asJsonObject(): \stdClass;
 
+	/**
+	 * @throws ClientExceptionInterface
+	 * @throws NetworkExceptionInterface
+	 */
     public function asXml(): string;
 
+	/**
+	 * @throws ClientExceptionInterface
+	 * @throws NetworkExceptionInterface
+	 */
     public function asCsv(): string;
 
     public function withTimeRestriction(?string $from = null, ?string $to = null): ClientInterface;

--- a/src/Client/LeadpagesClient.php
+++ b/src/Client/LeadpagesClient.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Scn\EvalancheReportingApiConnector\Client;
 
+use Psr\Http\Message\RequestFactoryInterface;
 use Scn\EvalancheReportingApiConnector\EvalancheConfigInterface;
 
 final class LeadpagesClient extends AbstractClient
@@ -11,10 +12,11 @@ final class LeadpagesClient extends AbstractClient
 
     public function __construct(
         ?int $customerId,
-        \GuzzleHttp\Client $http_client,
+        RequestFactoryInterface $requestFactory,
+        \Psr\Http\Client\ClientInterface $client,
         EvalancheConfigInterface $evalancheConfig
     ) {
-        parent::__construct($http_client, $evalancheConfig);
+        parent::__construct($requestFactory, $client, $evalancheConfig);
         $this->customerId = $customerId;
     }
 

--- a/src/Client/MilestoneProfileClient.php
+++ b/src/Client/MilestoneProfileClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Scn\EvalancheReportingApiConnector\Client;
 
+use Psr\Http\Message\RequestFactoryInterface;
 use Scn\EvalancheReportingApiConnector\EvalancheConfigInterface;
 
 final class MilestoneProfileClient extends AbstractClient
@@ -12,11 +13,12 @@ final class MilestoneProfileClient extends AbstractClient
 
     public function __construct(
         int $customerId,
-        \GuzzleHttp\Client $httpClient,
+        RequestFactoryInterface $requestFactory,
+        \Psr\Http\Client\ClientInterface $client,
         EvalancheConfigInterface $evalancheConfig
     )
     {
-        parent::__construct($httpClient, $evalancheConfig);
+        parent::__construct($requestFactory, $client, $evalancheConfig);
         $this->customerId = $customerId;
     }
 

--- a/src/Client/NewsletterSendlogsClient.php
+++ b/src/Client/NewsletterSendlogsClient.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Scn\EvalancheReportingApiConnector\Client;
 
+use Psr\Http\Message\RequestFactoryInterface;
 use Scn\EvalancheReportingApiConnector\EvalancheConfigInterface;
 
 final class NewsletterSendlogsClient extends AbstractClient
@@ -11,10 +12,11 @@ final class NewsletterSendlogsClient extends AbstractClient
 
     public function __construct(
         int $customerId,
-        \GuzzleHttp\Client $http_client,
+        RequestFactoryInterface $requestFactory,
+        \Psr\Http\Client\ClientInterface $client,
         EvalancheConfigInterface $evalancheConfig
     ) {
-        parent::__construct($http_client, $evalancheConfig);
+        parent::__construct($requestFactory, $client, $evalancheConfig);
         $this->customerId = $customerId;
     }
 

--- a/src/Client/ProfileChangelogsClient.php
+++ b/src/Client/ProfileChangelogsClient.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Scn\EvalancheReportingApiConnector\Client;
 
+use Psr\Http\Message\RequestFactoryInterface;
 use Scn\EvalancheReportingApiConnector\EvalancheConfigInterface;
 
 final class ProfileChangelogsClient extends AbstractClient
@@ -11,10 +12,11 @@ final class ProfileChangelogsClient extends AbstractClient
 
     public function __construct(
         int $pool_id,
-        \GuzzleHttp\Client $http_client,
+        RequestFactoryInterface $requestFactory,
+        \Psr\Http\Client\ClientInterface $client,
         EvalancheConfigInterface $evalancheConfig
     ) {
-        parent::__construct($http_client, $evalancheConfig);
+        parent::__construct($requestFactory, $client, $evalancheConfig);
         $this->pool_id = $pool_id;
     }
 

--- a/src/Client/ProfilesClient.php
+++ b/src/Client/ProfilesClient.php
@@ -3,15 +3,21 @@ declare(strict_types=1);
 
 namespace Scn\EvalancheReportingApiConnector\Client;
 
+use Psr\Http\Message\RequestFactoryInterface;
 use Scn\EvalancheReportingApiConnector\EvalancheConfigInterface;
 
 final class ProfilesClient extends AbstractClient
 {
     private $poolId;
 
-    public function __construct(int $poolId, \GuzzleHttp\Client $http_client, EvalancheConfigInterface $evalancheConfig)
+    public function __construct(
+    	int $poolId,
+	    RequestFactoryInterface $requestFactory,
+	    \Psr\Http\Client\ClientInterface $client,
+	    EvalancheConfigInterface $evalancheConfig
+    )
     {
-        parent::__construct($http_client, $evalancheConfig);
+        parent::__construct($requestFactory, $client, $evalancheConfig);
         $this->poolId = $poolId;
     }
 

--- a/src/EvalancheConnection.php
+++ b/src/EvalancheConnection.php
@@ -1,142 +1,113 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Scn\EvalancheReportingApiConnector;
 
-use GuzzleHttp\Client as GuzzleClient;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Scn\EvalancheReportingApiConnector\Client;
-use Scn\EvalancheReportingApiConnector\Enum\Language;
-use Scn\EvalancheReportingApiConnector\Enum\TimeFormat;
 
-final class EvalancheConnection
+final class EvalancheConnection implements EvalancheConnectionInterface
 {
+    private $requestFactory;
+
     private $config;
+
     private $httpClient;
 
     public function __construct(
-        EvalancheConfigInterface $config,
-        GuzzleClient $http_client
+        RequestFactoryInterface $requestFactory,
+        ClientInterface $httpClient,
+        EvalancheConfigInterface $config
     ) {
+        $this->requestFactory = $requestFactory;
+        $this->httpClient = $httpClient;
         $this->config = $config;
-        $this->httpClient = $http_client;
-    }
-
-    public static function create(
-        string $hostname,
-        string $username,
-        string $password,
-        string $language = Language::LANG_EN,
-        string $timeFormat = TimeFormat::ISO8601,
-        bool $debugMode = false
-    ): EvalancheConnection {
-        $clientConfig = [
-            'base_uri' => sprintf('https://%s', $hostname),
-            'auth' => [
-                $username,
-                $password,
-            ],
-            'verify' => !$debugMode,
-        ];
-
-        return new EvalancheConnection(
-            new EvalancheConfig(
-                $hostname,
-                $username,
-                $password,
-                $language,
-                $timeFormat
-            ),
-            new GuzzleClient($clientConfig)
-        );
     }
 
     public function getCheckpoints(int $customerId = null): Client\ClientInterface
     {
-        return new Client\CheckpointsClient($customerId, $this->httpClient, $this->config);
+        return new Client\CheckpointsClient($customerId, $this->requestFactory, $this->httpClient, $this->config);
     }
 
     public function getCheckpointStatistics(): Client\ClientInterface
     {
-        return $this->createClient(Client\CheckpointStatisticsClient::class);
+        return new Client\CheckpointStatisticsClient($this->requestFactory, $this->httpClient, $this->config);
     }
 
     public function getCustomers(): Client\ClientInterface
     {
-        return $this->createClient(Client\CustomersClient::class);
+        return new Client\CustomersClient($this->requestFactory, $this->httpClient, $this->config);
     }
 
     public function getForms(): Client\ClientInterface
     {
-        return $this->createClient(Client\FormsClient::class);
+        return new Client\FormsClient($this->requestFactory, $this->httpClient, $this->config);
     }
 
     public function getLeadpages(int $customerId = null): Client\ClientInterface
     {
-        return new Client\LeadpagesClient($customerId, $this->httpClient, $this->config);
+        return new Client\LeadpagesClient($customerId, $this->requestFactory, $this->httpClient, $this->config);
     }
 
     public function getMailings(): Client\ClientInterface
     {
-        return $this->createClient(Client\MailingsClient::class);
+        return new Client\MailingsClient($this->requestFactory, $this->httpClient, $this->config);
     }
 
     public function getPools(): Client\ClientInterface
     {
-        return $this->createClient(Client\PoolsClient::class);
+        return new Client\PoolsClient($this->requestFactory, $this->httpClient, $this->config);
     }
 
-    public function getProfileChangelogs(int $pool_id): Client\ClientInterface
+    public function getProfileChangelogs(int $poolId): Client\ClientInterface
     {
-        return new Client\ProfileChangelogsClient($pool_id, $this->httpClient, $this->config);
+        return new Client\ProfileChangelogsClient($poolId, $this->requestFactory, $this->httpClient, $this->config);
     }
 
-    public function getProfiles(int $pool_id): Client\ClientInterface
+    public function getProfiles(int $poolId): Client\ClientInterface
     {
-        return new Client\ProfilesClient($pool_id, $this->httpClient, $this->config);
+        return new Client\ProfilesClient($poolId, $this->requestFactory, $this->httpClient, $this->config);
     }
 
     public function getProfileScores(): Client\ClientInterface
     {
-        return $this->createClient(Client\ProfileScoresClient::class);
+        return new Client\ProfileScoresClient($this->requestFactory, $this->httpClient, $this->config);
     }
 
     public function getResourceTypes(): Client\ClientInterface
     {
-        return $this->createClient(Client\ResourceTypesClient::class);
+        return new Client\ResourceTypesClient($this->requestFactory, $this->httpClient, $this->config);
     }
 
     public function getScoringGroups(): Client\ClientInterface
     {
-        return $this->createClient(Client\ScoringGroupsClient::class);
+        return new Client\ScoringGroupsClient($this->requestFactory, $this->httpClient, $this->config);
     }
 
     public function getScoringHistory(): Client\ClientInterface
     {
-        return $this->createClient(Client\ScoringHistoryClient::class);
+        return new Client\ScoringHistoryClient($this->requestFactory, $this->httpClient, $this->config);
     }
 
     public function getTrackingHistory(): Client\ClientInterface
     {
-        return $this->createClient(Client\TrackingHistoryClient::class);
+        return new Client\TrackingHistoryClient($this->requestFactory, $this->httpClient, $this->config);
     }
 
     public function getTrackingTypes(): Client\ClientInterface
     {
-        return $this->createClient(Client\TrackingTypesClient::class);
+        return new Client\TrackingTypesClient($this->requestFactory, $this->httpClient, $this->config);
     }
 
-    public function getNewsletterSendlogs(int $customer_id): Client\ClientInterface
+    public function getNewsletterSendlogs(int $customerId): Client\ClientInterface
     {
-        return new Client\NewsletterSendlogsClient($customer_id, $this->httpClient, $this->config);
+        return new Client\NewsletterSendlogsClient($customerId, $this->requestFactory, $this->httpClient, $this->config);
     }
 
     public function getMilestoneProfiles(int $customerId): Client\ClientInterface
     {
-        return new Client\MilestoneProfileClient($customerId, $this->httpClient, $this->config);
-    }
-
-    private function createClient(string $clientClass): Client\ClientInterface
-    {
-        return new $clientClass($this->httpClient, $this->config);
+        return new Client\MilestoneProfileClient($customerId, $this->requestFactory, $this->httpClient, $this->config);
     }
 }

--- a/src/EvalancheConnectionInterface.php
+++ b/src/EvalancheConnectionInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Scn\EvalancheReportingApiConnector;
+
+interface EvalancheConnectionInterface
+{
+
+	public function getCheckpoints(int $customerId = null): Client\ClientInterface;
+
+	public function getCheckpointStatistics(): Client\ClientInterface;
+
+	public function getCustomers(): Client\ClientInterface;
+
+	public function getForms(): Client\ClientInterface;
+
+	public function getLeadpages(int $customerId = null): Client\ClientInterface;
+
+	public function getMailings(): Client\ClientInterface;
+
+	public function getPools(): Client\ClientInterface;
+
+	public function getProfileChangelogs(int $poolId): Client\ClientInterface;
+
+	public function getProfiles(int $poolId): Client\ClientInterface;
+
+	public function getProfileScores(): Client\ClientInterface;
+
+	public function getResourceTypes(): Client\ClientInterface;
+
+	public function getScoringGroups(): Client\ClientInterface;
+
+	public function getScoringHistory(): Client\ClientInterface;
+
+	public function getTrackingHistory(): Client\ClientInterface;
+
+	public function getTrackingTypes(): Client\ClientInterface;
+
+	public function getNewsletterSendlogs(int $customerId): Client\ClientInterface;
+
+	public function getMilestoneProfiles(int $customerId): Client\ClientInterface;
+}

--- a/src/Exception/AuthorizationException.php
+++ b/src/Exception/AuthorizationException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Scn\EvalancheReportingApiConnector\Exception;
-
-final class AuthorizationException extends \Exception
-{
-
-}

--- a/src/Exception/ConnectionException.php
+++ b/src/Exception/ConnectionException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Scn\EvalancheReportingApiConnector\Exception;
-
-final class ConnectionException extends \Exception
-{
-
-}

--- a/src/Exception/EmptyResultException.php
+++ b/src/Exception/EmptyResultException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Scn\EvalancheReportingApiConnector\Exception;
-
-final class EmptyResultException extends \Exception
-{
-
-}

--- a/src/Exception/InvalidParamException.php
+++ b/src/Exception/InvalidParamException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Scn\EvalancheReportingApiConnector\Exception;
-
-final class InvalidParamException extends \Exception
-{
-
-}

--- a/src/Exception/UnreachableEndpointException.php
+++ b/src/Exception/UnreachableEndpointException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Scn\EvalancheReportingApiConnector\Exception;
-
-final class UnreachableEndpointException extends \Exception
-{
-
-}

--- a/tests/EvalancheConfigTest.php
+++ b/tests/EvalancheConfigTest.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheReportingApiConnector;
 
+use PHPUnit\Framework\TestCase;
 use Scn\EvalancheReportingApiConnector\Enum\Language;
 use Scn\EvalancheReportingApiConnector\Enum\TimeFormat;
 
-class EvalancheConfigTest extends \PHPUnit\Framework\TestCase
+class EvalancheConfigTest extends TestCase
 {
     /**
      * @var EvalancheConfig
@@ -33,7 +36,7 @@ class EvalancheConfigTest extends \PHPUnit\Framework\TestCase
     private $timeFormat = TimeFormat::RFC1123;
 
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->subject = new EvalancheConfig(
             $this->hostname,
@@ -44,7 +47,7 @@ class EvalancheConfigTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testGetUsernameReturnsString()
+    public function testGetUsernameReturnsString(): void
     {
         $this->assertSame(
             $this->username,
@@ -52,7 +55,7 @@ class EvalancheConfigTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testGetHostnameReturnsString()
+    public function testGetHostnameReturnsString(): void
     {
         $this->assertSame(
             $this->hostname,
@@ -60,7 +63,7 @@ class EvalancheConfigTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testGetPasswordReturnsString()
+    public function testGetPasswordReturnsString(): void
     {
         $this->assertSame(
             $this->password,
@@ -68,7 +71,7 @@ class EvalancheConfigTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testGetLanguageReturnsString()
+    public function testGetLanguageReturnsString(): void
     {
         $this->assertSame(
             $this->language,
@@ -76,7 +79,7 @@ class EvalancheConfigTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testGetLanguageReturnsDefaultString()
+    public function testGetLanguageReturnsDefaultString(): void
     {
         $this->subject = new EvalancheConfig(
             $this->hostname,
@@ -92,7 +95,7 @@ class EvalancheConfigTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testGetTimeFormatReturnsString()
+    public function testGetTimeFormatReturnsString(): void
     {
         $this->assertSame(
             $this->timeFormat,
@@ -100,7 +103,7 @@ class EvalancheConfigTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testGetTimeFormatReturnsDefaultString()
+    public function testGetTimeFormatReturnsDefaultString(): void
     {
         $this->subject = new EvalancheConfig(
             $this->hostname,

--- a/tests/EvalancheConnectionTest.php
+++ b/tests/EvalancheConnectionTest.php
@@ -1,48 +1,38 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheReportingApiConnector;
 
-use Scn\EvalancheReportingApiConnector\Client\ProfilesClient;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 
-class EvalancheConnectionTest extends \PHPUnit\Framework\TestCase
+class EvalancheConnectionTest extends TestCase
 {
-
-    /**
-     * @var EvalancheConfigInterface
-     */
+    /** @var EvalancheConfigInterface|MockObject|null */
     protected $evalancheConfig;
-    /**
-     * @var EvalancheConnection
-     */
+
+    /** @var EvalancheConnection|null */
     private $subject;
-    /**
-     * @var \GuzzleHttp\Client
-     */
+
+    /** @var ClientInterface|MockObject|null */
     private $httpClient;
 
-    public function setUp()
+    /** @var RequestFactoryInterface|MockObject|null */
+    private $requestFactory;
+
+    public function setUp(): void
     {
-        $this->httpClient = $this->getMockBuilder(\GuzzleHttp\Client::class)->getMock();
-        $this->evalancheConfig = $this->getMockBuilder(EvalancheConfigInterface::class)->getMock();
+        $this->httpClient = $this->createMock(ClientInterface::class);
+        $this->requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $this->evalancheConfig = $this->createMock(EvalancheConfigInterface::class);
+
         $this->subject = new EvalancheConnection(
-            $this->evalancheConfig,
-            $this->httpClient
-        );
-    }
-
-    public function testCreateWithDefaultsReturnsInstance()
-    {
-        $this->assertInstanceOf(
-            EvalancheConnection::class,
-            $this->subject->create('my-host', 'my-user', 'my-password')
-        );
-    }
-
-    public function testCreateReturnsInstance()
-    {
-        $this->assertInstanceOf(
-            EvalancheConnection::class,
-            $this->subject->create('my-host', 'my-user', 'my-password', 'my-language', 'my-time-format', true)
+            $this->requestFactory,
+            $this->httpClient,
+            $this->evalancheConfig
         );
     }
 
@@ -52,7 +42,7 @@ class EvalancheConnectionTest extends \PHPUnit\Framework\TestCase
      * @param string $className
      * @param string $method
      */
-    public function testGetReturnsClient(string $className, string $method)
+    public function testGetReturnsClient(string $className, string $method): void
     {
         $this->assertInstanceOf(
             $className,
@@ -60,7 +50,7 @@ class EvalancheConnectionTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function clientDataProvider()
+    public function clientDataProvider(): array
     {
         return [
             [Client\CheckpointsClient::class, 'getCheckpoints'],
@@ -86,7 +76,7 @@ class EvalancheConnectionTest extends \PHPUnit\Framework\TestCase
      * @param string $method
      * @param int $param
      */
-    public function testGetWithParamReturnsClient(string $className, string $method, int $param)
+    public function testGetWithParamReturnsClient(string $className, string $method, int $param): void
     {
         $this->assertInstanceOf(
             $className,
@@ -94,7 +84,7 @@ class EvalancheConnectionTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function clientParamDataProvider()
+    public function clientParamDataProvider(): array
     {
         return [
             [Client\ProfileChangelogsClient::class, 'getProfileChangelogs', 42],


### PR DESCRIPTION
To be a far more developer-friends library, we drop guzzle as pre-set
http client and switch over to PSR18 clients.

- Bump required php version to 7.3
- Drop Exception as we passthru the client exceptions